### PR TITLE
Add support to data source rewinding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 		<dependency>
 			<groupId>com.wounit</groupId>
 			<artifactId>wounit</artifactId>
-			<version>1.2.2</version>
+			<version>1.3-beta-2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/woreports/jasper/data/JasperEOBatchDataSource.java
+++ b/src/main/java/com/woreports/jasper/data/JasperEOBatchDataSource.java
@@ -15,6 +15,7 @@ import er.extensions.eof.ERXFetchSpecificationBatchIterator;
 import net.sf.jasperreports.engine.JRDataSource;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JRField;
+import net.sf.jasperreports.engine.JRRewindableDataSource;
 
 /**
  * EOF implementation of Jasper data source. This class provides a way to
@@ -40,10 +41,13 @@ import net.sf.jasperreports.engine.JRField;
  * <p>
  * The raw row option is activated while fetching data to reduce memory
  * consumption.
- * 
+ * <p>
+ * This class implements the {@code JRRewindableDataSource} interface, allowing the iteration to go back to the first
+ * element.
+ *
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  */
-public class JasperEOBatchDataSource implements JRDataSource {
+public class JasperEOBatchDataSource implements JRDataSource, JRRewindableDataSource {
     private final ERXFetchSpecificationBatchIterator iterator;
 
     private NSDictionary<String, Object> row;
@@ -85,6 +89,11 @@ public class JasperEOBatchDataSource implements JRDataSource {
         Object value = row.valueForKeyPath(field.getName());
 
         return value == NSKeyValueCoding.NullValue ? null : value;
+    }
+
+    @Override
+    public void moveFirst() throws JRException {
+        iterator.reset();
     }
 
     @Override

--- a/src/main/java/com/woreports/jasper/data/JasperEODataSource.java
+++ b/src/main/java/com/woreports/jasper/data/JasperEODataSource.java
@@ -13,6 +13,7 @@ import com.webobjects.foundation.NSKeyValueCoding;
 import net.sf.jasperreports.engine.JRDataSource;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JRField;
+import net.sf.jasperreports.engine.JRRewindableDataSource;
 
 /**
  * EOF implementation of Jasper data source. This class provides a way to
@@ -37,10 +38,13 @@ import net.sf.jasperreports.engine.JRField;
  * <p>
  * The raw row option is activated while fetching data to reduce memory
  * consumption.
- * 
+ * <p>
+ * This class implements the {@code JRRewindableDataSource} interface, allowing the iteration to go back to the first
+ * element.
+ *
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  */
-public class JasperEODataSource implements JRDataSource {
+public class JasperEODataSource implements JRDataSource, JRRewindableDataSource {
     private final EOEditingContext editingContext;
 
     private final String entityName;
@@ -93,6 +97,11 @@ public class JasperEODataSource implements JRDataSource {
         }
 
         return value;
+    }
+
+    @Override
+    public void moveFirst() throws JRException {
+        index = -1;
     }
 
     @Override

--- a/src/main/java/com/woreports/jasper/data/JasperEOGlobaIDDataSource.java
+++ b/src/main/java/com/woreports/jasper/data/JasperEOGlobaIDDataSource.java
@@ -1,9 +1,6 @@
 package com.woreports.jasper.data;
 
 import static er.extensions.eof.ERXEOControlUtilities.objectsForGlobalIDs;
-import net.sf.jasperreports.engine.JRDataSource;
-import net.sf.jasperreports.engine.JRException;
-import net.sf.jasperreports.engine.JRField;
 
 import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.eocontrol.EOGlobalID;
@@ -11,12 +8,19 @@ import com.webobjects.foundation.NSArray;
 
 import er.extensions.eof.ERXEC;
 import er.extensions.eof.ERXEC.Factory;
+import net.sf.jasperreports.engine.JRDataSource;
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JRField;
+import net.sf.jasperreports.engine.JRRewindableDataSource;
 
 /**
+ * This class implements the {@code JRRewindableDataSource} interface, allowing the iteration to go back to the first
+ * element.
+ *
  * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
  */
-public class JasperEOGlobaIDDataSource implements JRDataSource {
-    private JRDataSource dataSource;
+public class JasperEOGlobaIDDataSource implements JRDataSource, JRRewindableDataSource {
+    private JasperKeyValueDataSource dataSource;
     private final Factory editingContextFactory;
     private final NSArray<EOGlobalID> globalIds;
 
@@ -38,7 +42,7 @@ public class JasperEOGlobaIDDataSource implements JRDataSource {
     }
 
     @SuppressWarnings("unchecked")
-    private JRDataSource dataSource() {
+    private JasperKeyValueDataSource dataSource() {
         if (dataSource == null) {
             EOEditingContext editingContext = editingContextFactory._newEditingContext();
 
@@ -51,6 +55,11 @@ public class JasperEOGlobaIDDataSource implements JRDataSource {
     @Override
     public Object getFieldValue(JRField field) throws JRException {
         return dataSource().getFieldValue(field);
+    }
+
+    @Override
+    public void moveFirst() throws JRException {
+        dataSource().moveFirst();
     }
 
     @Override

--- a/src/main/java/com/woreports/jasper/data/JasperKeyValueDataSource.java
+++ b/src/main/java/com/woreports/jasper/data/JasperKeyValueDataSource.java
@@ -9,6 +9,7 @@ import com.webobjects.foundation.NSKeyValueCodingAdditions;
 import net.sf.jasperreports.engine.JRDataSource;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JRField;
+import net.sf.jasperreports.engine.JRRewindableDataSource;
 
 /**
  * Implementation of <code>JRDataSource</code> to support
@@ -35,10 +36,13 @@ import net.sf.jasperreports.engine.JRField;
  * </ul>
  * <p>
  * This class also supports objects that do not implement the NSKeyValueCoding interface.
- * 
+ * <p>
+ * This class implements the {@code JRRewindableDataSource} interface, allowing the iteration to go back to the first
+ * element.
+ *
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  */
-public class JasperKeyValueDataSource implements JRDataSource {
+public class JasperKeyValueDataSource implements JRDataSource, JRRewindableDataSource {
     private int index = -1;
 
     private final List<? extends Object> objects;
@@ -62,6 +66,11 @@ public class JasperKeyValueDataSource implements JRDataSource {
         Object value = NSKeyValueCodingAdditions.Utility.valueForKeyPath(object, field.getName());
 
         return value == NSKeyValueCoding.NullValue ? null : value;
+    }
+
+    @Override
+    public void moveFirst() throws JRException {
+        index = -1;
     }
 
     @Override

--- a/src/test/java/com/woreports/jasper/data/TestJasperEODataSource.java
+++ b/src/test/java/com/woreports/jasper/data/TestJasperEODataSource.java
@@ -6,29 +6,21 @@ import static org.junit.Assert.fail;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 
-import com.webobjects.foundation.NSArray;
-import com.webobjects.foundation.NSDictionary;
 import com.woreports.model.Foo;
 import com.wounit.rules.MockEditingContext;
 
 /**
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  */
-@RunWith(value = MockitoJUnitRunner.class)
 public class TestJasperEODataSource {
-    protected static final String ENTITY_NAME = "entity";
-
     @Rule
-    public MockEditingContext mockEditingContext = new MockEditingContext("Sample");
+    public MockEditingContext editingContext = new MockEditingContext("Sample");
 
     @Test
     public void cannotCreateIfEditingContextIsNull() throws Exception {
         try {
-            new JasperEODataSource(null, ENTITY_NAME);
+            new JasperEODataSource(null, Foo.ENTITY_NAME);
 
             fail();
         } catch (IllegalArgumentException exception) {
@@ -39,7 +31,7 @@ public class TestJasperEODataSource {
     @Test
     public void cannotCreateIfEntityNameIsNull() throws Exception {
         try {
-            new JasperEODataSource(mockEditingContext, null);
+            new JasperEODataSource(editingContext, null);
 
             fail();
         } catch (IllegalArgumentException exception) {
@@ -49,27 +41,25 @@ public class TestJasperEODataSource {
 
     @Test
     public void nextReturnsFalseIfHasNoObjects() throws Exception {
-        JasperEODataSource dataSource = Mockito.spy(new JasperEODataSource(mockEditingContext, ENTITY_NAME));
-
-        Mockito.doReturn(NSArray.emptyArray()).when(dataSource).resultSet();
+        JasperEODataSource dataSource = new JasperEODataSource(editingContext, Foo.ENTITY_NAME);
 
         assertThat(dataSource.next(), is(false));
     }
 
     @Test
     public void nextReturnsTrueIfHasObjects() throws Exception {
-        JasperEODataSource dataSource = Mockito.spy(new JasperEODataSource(mockEditingContext, ENTITY_NAME));
+        editingContext.createSavedObject(Foo.class);
 
-        Mockito.doReturn(new NSArray<NSDictionary<String, ? extends Object>>(new NSDictionary<String, Object>())).when(dataSource).resultSet();
+        JasperEODataSource dataSource = new JasperEODataSource(editingContext, Foo.ENTITY_NAME);
 
         assertThat(dataSource.next(), is(true));
     }
 
     @Test
     public void rewindToFirstElement() throws Exception {
-        mockEditingContext.createSavedObject(Foo.class);
+        editingContext.createSavedObject(Foo.class);
 
-        JasperEODataSource dataSource = new JasperEODataSource(mockEditingContext, Foo.ENTITY_NAME);
+        JasperEODataSource dataSource = new JasperEODataSource(editingContext, Foo.ENTITY_NAME);
 
         dataSource.next();
         dataSource.next();

--- a/src/test/java/com/woreports/jasper/data/TestJasperEODataSource.java
+++ b/src/test/java/com/woreports/jasper/data/TestJasperEODataSource.java
@@ -4,16 +4,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
-import com.woreports.jasper.data.JasperEODataSource;
+import com.woreports.model.Foo;
+import com.wounit.rules.MockEditingContext;
 
 /**
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
@@ -22,8 +22,8 @@ import com.woreports.jasper.data.JasperEODataSource;
 public class TestJasperEODataSource {
     protected static final String ENTITY_NAME = "entity";
 
-    @Mock
-    protected EOEditingContext mockEditingContext;
+    @Rule
+    public MockEditingContext mockEditingContext = new MockEditingContext("Sample");
 
     @Test
     public void cannotCreateIfEditingContextIsNull() throws Exception {
@@ -61,6 +61,20 @@ public class TestJasperEODataSource {
         JasperEODataSource dataSource = Mockito.spy(new JasperEODataSource(mockEditingContext, ENTITY_NAME));
 
         Mockito.doReturn(new NSArray<NSDictionary<String, ? extends Object>>(new NSDictionary<String, Object>())).when(dataSource).resultSet();
+
+        assertThat(dataSource.next(), is(true));
+    }
+
+    @Test
+    public void rewindToFirstElement() throws Exception {
+        mockEditingContext.createSavedObject(Foo.class);
+
+        JasperEODataSource dataSource = new JasperEODataSource(mockEditingContext, Foo.ENTITY_NAME);
+
+        dataSource.next();
+        dataSource.next();
+
+        dataSource.moveFirst();
 
         assertThat(dataSource.next(), is(true));
     }

--- a/src/test/java/com/woreports/jasper/data/TestJasperEOGlobalIDDataSource.java
+++ b/src/test/java/com/woreports/jasper/data/TestJasperEOGlobalIDDataSource.java
@@ -1,0 +1,39 @@
+package com.woreports.jasper.data;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.woreports.model.Foo;
+import com.wounit.rules.MockEditingContext;
+import com.wounit.utils.WOUnitEditingContextFactory;
+
+/**
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+public class TestJasperEOGlobalIDDataSource {
+    private JasperEOGlobaIDDataSource dataSource;
+
+    @Rule
+    public MockEditingContext editingContext = new MockEditingContext("Sample");
+
+    @Before
+    public void setup() {
+        Foo eo = editingContext.createSavedObject(Foo.class);
+
+        dataSource = new JasperEOGlobaIDDataSource(new WOUnitEditingContextFactory(editingContext), editingContext.globalIDForObject(eo));
+    }
+
+    @Test
+    public void rewindToFirstElement() throws Exception {
+        dataSource.next();
+        dataSource.next();
+
+        dataSource.moveFirst();
+
+        assertThat(dataSource.next(), is(true));
+    }
+}

--- a/src/test/java/com/woreports/jasper/data/TestJasperKeyValueDataSource.java
+++ b/src/test/java/com/woreports/jasper/data/TestJasperKeyValueDataSource.java
@@ -5,7 +5,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import net.sf.jasperreports.engine.JRField;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -21,11 +20,12 @@ import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSKeyValueCoding;
 import com.webobjects.foundation.NSMutableDictionary;
-import com.woreports.jasper.data.JasperKeyValueDataSource;
 import com.woreports.model.Foo;
 import com.woreports.model.FooRelated;
 import com.woreports.model.StubObject;
 import com.wounit.rules.MockEditingContext;
+
+import net.sf.jasperreports.engine.JRField;
 
 /**
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
@@ -188,6 +188,16 @@ public class TestJasperKeyValueDataSource {
     public void iterateOverOneRecord() throws Exception {
         assertThat(dataSource.next(), is(true));
         assertThat(dataSource.next(), is(false));
+    }
+
+    @Test
+    public void rewindToFirstElement() throws Exception {
+        dataSource.next();
+        dataSource.next();
+
+        dataSource.moveFirst();
+
+        assertThat(dataSource.next(), is(true));
     }
 
     @Before


### PR DESCRIPTION
Improve data sources by implementing the interface `JRRewindableDataSource`. It allows data sources to iterate back to the first element.