### PR TITLE
Add a data source wrapper class to rewind data sources

### DIFF
--- a/src/main/java/com/woreports/jasper/data/JasperRewindableDataSourceWrapper.java
+++ b/src/main/java/com/woreports/jasper/data/JasperRewindableDataSourceWrapper.java
@@ -1,0 +1,53 @@
+package com.woreports.jasper.data;
+
+import static java.util.Objects.requireNonNull;
+
+import org.apache.commons.lang.UnhandledException;
+
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JRField;
+import net.sf.jasperreports.engine.JRRewindableDataSource;
+
+/**
+ * This class acts as a data source wrapper and rewinds the provided data source upon creation. That feature is very
+ * useful when a report contains a subreport inside the detail band. By passing the data source wrapped by this class to
+ * the subreport will move the pointer to the first record for each iteration of the detail band.
+ *
+ * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
+ */
+public class JasperRewindableDataSourceWrapper implements JRRewindableDataSource {
+    private final JRRewindableDataSource dataSource;
+
+    /**
+     * Wraps the provided data source moving the pointer to the first position before initial processing.
+     *
+     * @param dataSource
+     *            A rewindable data source.
+     */
+    public JasperRewindableDataSourceWrapper(JRRewindableDataSource dataSource) {
+        requireNonNull(dataSource, "The data source parameter cannot be null");
+
+        this.dataSource = dataSource;
+
+        try {
+            this.dataSource.moveFirst();
+        } catch (JRException exception) {
+            throw new UnhandledException("An error has occurred while trying to rewind the data source", exception);
+        }
+    }
+
+    @Override
+    public boolean next() throws JRException {
+        return dataSource.next();
+    }
+
+    @Override
+    public Object getFieldValue(JRField jrField) throws JRException {
+        return dataSource.getFieldValue(jrField);
+    }
+
+    @Override
+    public void moveFirst() throws JRException {
+        dataSource.moveFirst();
+    }
+}

--- a/src/test/java/com/woreports/jasper/data/TestJasperRewindableDataSourceWrapper.java
+++ b/src/test/java/com/woreports/jasper/data/TestJasperRewindableDataSourceWrapper.java
@@ -1,0 +1,80 @@
+package com.woreports.jasper.data;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import org.apache.commons.lang.UnhandledException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JRRewindableDataSource;
+
+/**
+ * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TestJasperRewindableDataSourceWrapper {
+    @Mock
+    private JRRewindableDataSource dataSource;
+
+    private JasperRewindableDataSourceWrapper wrapper;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        wrapper = new JasperRewindableDataSourceWrapper(dataSource);
+    }
+
+    @Test
+    public void rewindDataSourceWhenCreatingDataSourceWrapper() throws Exception {
+        verify(dataSource).moveFirst();
+    }
+
+    @Test
+    public void delegateMethodInvocationsToDataSourceWhenCallingWrapperMethods() throws Exception {
+        reset(dataSource);
+
+        wrapper.moveFirst();
+
+        verify(dataSource).moveFirst();
+
+        wrapper.next();
+
+        verify(dataSource).next();
+
+        wrapper.getFieldValue(null);
+
+        verify(dataSource).getFieldValue(null);
+    }
+
+    @Test
+    public void throwExceptionWhenWrappingNullDataSource() throws Exception {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage(is("The data source parameter cannot be null"));
+
+        new JasperRewindableDataSourceWrapper(null);
+    }
+
+    @Test
+    public void throwChainedRuntimeExceptionWhenMovingToFirstDuringCreation() throws Exception {
+        JRException exception = new JRException("error");
+
+        doThrow(exception).when(dataSource).moveFirst();
+
+        thrown.expect(UnhandledException.class);
+        thrown.expectMessage(is("An error has occurred while trying to rewind the data source"));
+        thrown.expectCause(is(exception));
+
+        new JasperRewindableDataSourceWrapper(dataSource);
+    }
+}


### PR DESCRIPTION
The JasperRewindableDataSourceWrapper can rewind the same data source used multiple times in subreports.