### PR TITLE
Accept a supplier of editing context when creating JasperEOGlobalIDDataSources

### DIFF
--- a/src/main/java/com/woreports/jasper/data/JasperEOGlobaIDDataSource.java
+++ b/src/main/java/com/woreports/jasper/data/JasperEOGlobaIDDataSource.java
@@ -13,6 +13,8 @@ import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JRField;
 import net.sf.jasperreports.engine.JRRewindableDataSource;
 
+import java.util.function.Supplier;
+
 /**
  * This class implements the {@code JRRewindableDataSource} interface, allowing the iteration to go back to the first
  * element.
@@ -21,11 +23,11 @@ import net.sf.jasperreports.engine.JRRewindableDataSource;
  */
 public class JasperEOGlobaIDDataSource implements JRDataSource, JRRewindableDataSource {
     private JasperKeyValueDataSource dataSource;
-    private final Factory editingContextFactory;
+    private final Supplier<EOEditingContext> editingContextSupplier;
     private final NSArray<EOGlobalID> globalIds;
 
     public JasperEOGlobaIDDataSource(EOGlobalID... globalIds) {
-        this(new NSArray<EOGlobalID>(globalIds));
+        this(new NSArray<>(globalIds));
     }
 
     public JasperEOGlobaIDDataSource(NSArray<EOGlobalID> globalIds) {
@@ -33,17 +35,25 @@ public class JasperEOGlobaIDDataSource implements JRDataSource, JRRewindableData
     }
 
     public JasperEOGlobaIDDataSource(ERXEC.Factory editingContextFactory, EOGlobalID... globalIds) {
-        this(editingContextFactory, new NSArray<EOGlobalID>(globalIds));
+        this(editingContextFactory, new NSArray<>(globalIds));
     }
 
     public JasperEOGlobaIDDataSource(ERXEC.Factory editingContextFactory, NSArray<EOGlobalID> globalIds) {
-        this.editingContextFactory = editingContextFactory;
+        this(() -> editingContextFactory._newEditingContext(), globalIds);
+    }
+
+    public JasperEOGlobaIDDataSource(Supplier<EOEditingContext> editingContextSupplier, EOGlobalID... globalIds) {
+        this(editingContextSupplier, new NSArray<>(globalIds));
+    }
+
+    public JasperEOGlobaIDDataSource(Supplier<EOEditingContext> editingContextSupplier, NSArray<EOGlobalID> globalIds) {
+        this.editingContextSupplier = editingContextSupplier;
         this.globalIds = globalIds;
     }
 
     private JasperKeyValueDataSource dataSource() {
         if (dataSource == null) {
-            EOEditingContext editingContext = editingContextFactory._newEditingContext();
+            EOEditingContext editingContext = editingContextSupplier.get();
 
             dataSource = new JasperKeyValueDataSource(objectsForGlobalIDs(editingContext, globalIds));
         }


### PR DESCRIPTION
Adds a new constructor to the `JasperEOGlobalIDDataSource` that accepts a `Supplier<EOEditingContext>`. This constructor may be useful when processing reports in a separate thread using an alternative parent object store coordinator.